### PR TITLE
Fix browser exec mode

### DIFF
--- a/__tests__/e2e/e2e-runner.cjs
+++ b/__tests__/e2e/e2e-runner.cjs
@@ -9,7 +9,7 @@ const createTestCafe = require('testcafe');
             .src(['__tests__/e2e/'])
             .browsers([
                 // userAgent assignment is only for chrome browser
-                'chrome:emulation:userAgent=TEST_CAFE_REGRESSION',
+                'chrome:headless:userAgent=TEST_CAFE_REGRESSION',
             ])
             .run();
     } finally {


### PR DESCRIPTION
# WHAT

- E2E test のブラウザ実行モードを CI 用に emulation から headless モードに変更しました。